### PR TITLE
Update ViperToken.sol

### DIFF
--- a/contracts/ViperToken.sol
+++ b/contracts/ViperToken.sol
@@ -2,9 +2,9 @@
 // We will be using Solidity version 0.5.3
 pragma solidity 0.5.3;
 // Importing OpenZeppelin's ERC-721 Implementation
-import 'https://github.com/OpenZeppelin/openzeppelin-solidity/contracts/token/ERC721/ERC721Full.sol';
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v2.3.0/contracts/token/ERC721/ERC721Full.sol";
 // Importing OpenZeppelin's SafeMath Implementation
-import 'https://github.com/OpenZeppelin/openzeppelin-solidity/contracts/math/SafeMath.sol';
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v2.3.0/contracts/math/SafeMath.sol";
 
 
 contract ViperToken is ERC721Full {


### PR DESCRIPTION
Importing OpenZeppelin Contracts from GitHub should specify a release tag

Fixes: https://github.com/openberry-ac/cryptovipers/issues/2